### PR TITLE
Units of eVs and Angstroms

### DIFF
--- a/Modules/constants.py
+++ b/Modules/constants.py
@@ -1,9 +1,11 @@
-hhbar = 6.58211899e-16          #h/2π in [eV*s]
-hbar = 1.054571726e-34          #h/2π in [J*s]
+Jtoev = 1/(1.602176487e-19)     #Conversion of Joules to eV
+evtoJ = 1.602176487e-19         #Conversion of eV to Joules
+
+hbar = 6.58211899e-16           #h/2π in [eV*s]
+hbarJ = 1.054571726e-34         #h/2π in [J*s]
 m0 = 9.10938215e-31             #electron mass in [kg]
 e0 = 1.602176487e-19            #electron charge in [C]
-ηm = (hbar**2*e0*10**20)/m0     #hbar^2/mo in [eV A^2]
-μB = 5.7883818066e-2            #in [meV/T]
+xi = (hbar**2*e0*10**20)/m0     #hbar^2/mo in [eV A^2]
+
+μB = 5.7883818066e-2            #[meV/T]
 meVpK = 8.6173325e-2            #Kelvin into [meV]
-Jtoev = 6.242e18                #Conversion of Joules to eV
-evtoJ = 6.242e-18               #Conversion of eV to Joules

--- a/Modules/operators.py
+++ b/Modules/operators.py
@@ -172,7 +172,7 @@ def V_periodic(V0, Nx, Ny, coor):
 def H0(coor, ax, ay):
     N = coor.shape[0]
     H = np.zeros((N,N), dtype = 'complex')
-    H = (const.hbar**2/(2*const.m0))*(k_x2(coor, ax, ay) + k_y2(coor, ax, ay))
+    H = (const.xi/2)*(k_x2(coor, ax, ay) + k_y2(coor, ax, ay))
     return H
 
 #Spin orbit coupling, spin energy splitting, size 2Nx2N: 0->N spin up states, N -> 2N spin down states
@@ -195,7 +195,7 @@ def H_SOC(coor, ax, ay, V, gamma, alpha):
 def H0k(qx, qy, coor, ax, ay):
     N = coor.shape[0]
     H = np.zeros((N,N), dtype = 'complex')
-    H = (const.hbar**2/(2*const.m0))*(kp_x2(qx, coor, ax, ay) + kp_y2(qy, coor, ax, ay))
+    H = (const.xi/2)*(kp_x2(qx, coor, ax, ay) + kp_y2(qy, coor, ax, ay))
     return H
 
 def H_SOCk(qx, qy, coor, ax, ay, V, gamma, alpha):
@@ -231,9 +231,9 @@ def state_cplot(coor, states):
 
 def bands(eigarr, q):
     for j in range(eigarr.shape[1]):
-        plt.plot(q, (6.242e18)*eigarr[:, j], c ='b', linestyle = 'solid')
+        plt.plot(q, eigarr[:, j], c ='b', linestyle = 'solid')
     plt.plot(np.linspace(min(q), max(q), 1000), 0*np.linspace(min(q), max(q), 1000), c='k', linestyle='solid', lw=1)
     plt.xticks(np.arange(-np.pi/Lx, np.pi/Lx+0.1*(np.pi/Lx), (np.pi/Lx)), ('-π/Lx', '0', 'π/Lx'))
-    plt.xlabel('k [1/m]')
+    plt.xlabel('k [1/A]')
     plt.ylabel('Energy [eV]')
     plt.show()

--- a/Tests/Free Particle/Ibeam_FP.py
+++ b/Tests/Free Particle/Ibeam_FP.py
@@ -12,8 +12,8 @@ import lattice as lat
 import constants as const
 import operators as op
 
-ax = 2e-10  #unit cell size along x-direction in [m]
-ay = 2e-10  #unit cell size along y-direction in [m]
+ax = 2      #unit cell size along x-direction in [A]
+ay = 2      #unit cell size along y-direction in [A]
 Ny = 25     #number of lattice sites in y direction
 Nx = 25     #number of lattice sites in x direction
 N = Ny*Nx   #Total number of lattice sites

--- a/Tests/Free Particle/cross_FP.py
+++ b/Tests/Free Particle/cross_FP.py
@@ -12,8 +12,8 @@ import lattice as lat
 import constants as const
 import operators as op
 
-ax = 2e-10  #unit cell size along x-direction in [m]
-ay = 2e-10  #unit cell size along y-direction in [m]
+ax = 2      #unit cell size along x-direction in [A]
+ay = 2      #unit cell size along y-direction in [A]
 Ny = 25     #number of lattice sites in y direction
 Nx = 25     #number of lattice sites in x direction
 N = Ny*Nx   #Total number of lattice sites

--- a/Tests/Free Particle/donut_FP.py
+++ b/Tests/Free Particle/donut_FP.py
@@ -12,8 +12,8 @@ import lattice as lat
 import constants as const
 import operators as op
 
-ax = 2e-10  #unit cell size along x-direction in [m]
-ay = 2e-10  #unit cell size along y-direction in [m]
+ax = 2      #unit cell size along x-direction in [A]
+ay = 2      #unit cell size along y-direction in [A]
 Ny = 25     #number of lattice sites in y direction
 Nx = 25     #number of lattice sites in x direction
 N = Ny*Nx   #Total number of lattice sites

--- a/Tests/Free Particle/halfdisk_FP.py
+++ b/Tests/Free Particle/halfdisk_FP.py
@@ -12,8 +12,8 @@ import lattice as lat
 import constants as const
 import operators as op
 
-ax = 2e-10  #unit cell size along x-direction in [m]
-ay = 2e-10  #unit cell size along y-direction in [m]
+ax = 2      #unit cell size along x-direction in [A]
+ay = 2      #unit cell size along y-direction in [A]
 Ny = 25     #number of lattice sites in y direction
 Nx = 25     #number of lattice sites in x direction
 N = Ny*Nx   #Total number of lattice sites

--- a/Tests/Free Particle/square_FP.py
+++ b/Tests/Free Particle/square_FP.py
@@ -12,8 +12,8 @@ import lattice as lat
 import constants as const
 import operators as op
 
-ax = 2e-10  #unit cell size along x-direction in [m]
-ay = 2e-10  #unit cell size along y-direction in [m]
+ax = 2      #unit cell size along x-direction in [A]
+ay = 2      #unit cell size along y-direction in [A]
 Ny = 25     #number of lattice sites in y direction
 Nx = 25     #number of lattice sites in x direction
 N = Ny*Nx   #Total number of lattice sites

--- a/Tests/Periodic/square_periodic.py
+++ b/Tests/Periodic/square_periodic.py
@@ -9,12 +9,13 @@ import lattice as lat
 import constants as const
 import operators as op
 
-print("hbar = {} [J*s]".format(const.hbar))
-print("hbar = {} [ev*s]".format(const.hhbar))
+print("hbar = {} [J*s]".format(const.hbarJ))
+print("hbar = {} [ev*s]".format(const.hbar))
 print("mass of electron = {} [kg]".format(const.m0))
+print("hbar**2/m0 = {} [eV A^2]".format(const.xi))
 
-ax = 2e-10  #atomic spacing along x-direction in [m]
-ay = 2e-10  #atomic spacing along y-direction in [m]
+ax = 2      #atomic spacing along x-direction in [A]
+ay = 2      #atomic spacing along y-direction in [A]
 
 Nx = 3      #number of lattice sites in x direction
 Ny = 3      #number of lattice sites in y direction
@@ -23,8 +24,8 @@ N = Ny*Nx   #Total number of lattice sites
 Lx = Nx*ax  #Unit cell size in y-direction
 Ly = Ny*ay  #Unit cell size in y-direction
 
-tx = -const.hbar**2/(2*const.m0*ax**2) #Hopping in [J]
-ty = -const.hbar**2/(2*const.m0*ay**2) #Hopping in [J]
+tx = -const.xi/(ax**2) #Hopping in [eV]
+ty = -const.xi/(ay**2) #Hopping in [eV]
 
 print("Number of Lattice Sites= ", N)
 print("Unit cell size in x-direction = {} [m] = {} [A]".format(Lx, Lx*1e10))
@@ -50,9 +51,9 @@ op.bands(eigarr, qx, Lx, Ly)
 
 #H_SOC(coor, ax, ay, V, gamma, alpha)
 #V_periodic(V0, Nx, Ny, coor)
-alpha = 0.02*1e-10*const.evtoJ #[J*m]
-gamma = 0.01*const.evtoJ  #[T]
-V0 = 0.1*const.evtoJ
+alpha = 0.2   #[eV*A]
+gamma = 0*0.01  #[T]
+V0 = 0.1
 
 steps = 50
 nbands = 18


### PR DESCRIPTION
Changed units in H0 and H0k operators wit the use of xi constant. Units of energy are now correctly given in [eV] and the inputs in the operators for ax and ay are given in units of Angstroms